### PR TITLE
Hotfix(badge): update text at last minute

### DIFF
--- a/src/js/timer.js
+++ b/src/js/timer.js
@@ -47,9 +47,13 @@ class Timer {
 						this.resetTimer();
 					} else {
 						const minutesLeft = getMillisecondsToMinutesAndSeconds(timeLeft).minutes.toString();
+						const secondsLeft = getMillisecondsToMinutesAndSeconds(timeLeft).seconds;
 
 						if (this.badge.getBadgeText() !== minutesLeft) {
-							this.badge.setBadgeText(minutesLeft);
+							if (minutesLeft === '0' && secondsLeft < 60)
+								this.badge.setBadgeText('<1');
+							else
+								this.badge.setBadgeText(minutesLeft);
 						}
 					}
 				}, getSecondsInMilliseconds(1)),

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Tomato Clock",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": "Samuel Jun",
   "description": "A simple browser extension for managing your productivity.",
 


### PR DESCRIPTION
Simple fix to display '<1' instead of '0' at the last minute on the badge's text.