### PR TITLE
Fix README npm command for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please file any issues or feature requests at https://github.com/samueljun/tomat
 2. Install the required node modules:
 
 ```sh
-npm run watch
+npm install
 ```
 
 3. Run the following command so that webpack can watch and recompile the `/src` files live to the `/dist` folder:


### PR DESCRIPTION
The command 'npm run watch' was written instead of 'npm install' in the development section of the README.