### PR TITLE
removed erroneous modulo

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -11,13 +11,13 @@ export function getMinutesInMilliseconds(minutes) {
 
 export function getMillisecondsToMinutesAndSeconds(milliseconds) {
   return {
-    minutes: parseInt((milliseconds / (1000 * 60)) % 60),
+    minutes: parseInt(milliseconds / (1000 * 60)),
     seconds: parseInt((milliseconds / 1000) % 60),
   };
 }
 
 export function getMillisecondsToTimeText(milliseconds) {
-  const minutes = parseInt((milliseconds / (1000 * 60)) % 60);
+  const minutes = parseInt(milliseconds / (1000 * 60));
   const seconds = parseInt((milliseconds / 1000) % 60);
   const minutesString = minutes < 10 ? `0${minutes}` : minutes.toString();
   const secondsString = seconds < 10 ? `0${seconds}` : seconds.toString();


### PR DESCRIPTION
panel could not correctly display "Minutes in Tomato" values >59min

e.g.
60min displayed as 00:00
62min as 02:00
90min as 30:00

it would just show the modulo overflow, not the complete minutes!

(both this time :see_no_evil:)